### PR TITLE
Fix help output for positional arguments.

### DIFF
--- a/test/System/Console/GetOpt/Generics/ModifierSpec.hs
+++ b/test/System/Console/GetOpt/Generics/ModifierSpec.hs
@@ -35,7 +35,7 @@ spec = do
     describe "parseArguments" $ do
       it "allows to specify a flag specific help" $ do
         let OutputAndExit output =
-              parseArguments "header" [AddOptionHelp "bar" "bar help text"]
+              parseArguments "prog-name" [AddOptionHelp "bar" "bar help text"]
                 (words "--help") :: Result Foo
         output `shouldContain` "--bar=string  bar help text"
 


### PR DESCRIPTION
This PR means that the meaning of the first parameter to `parseArguments` changes from `header` to `progName`. What it gives us is a slightly better help output:

```
Example.hs [OPTIONS]
      --bar=string
      --baz=string (optional)
      --qux=integer
  -h  --help                   show help and exit
```

Any opinion?
