### PR TITLE
Prepare for generics-sop-0.2.

### DIFF
--- a/getopt-generics.cabal
+++ b/getopt-generics.cabal
@@ -49,7 +49,7 @@ library
       base == 4.*
     , base-compat >= 0.8
     , base-orphans
-    , generics-sop
+    , generics-sop >= 0.1 && < 0.3
     , tagged
   exposed-modules:
       WithCli

--- a/src/System/Console/GetOpt/Generics.hs
+++ b/src/System/Console/GetOpt/Generics.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module System.Console.GetOpt.Generics (
   -- * Simple IO API


### PR DESCRIPTION
I'm about to release generics-sop-0.2 today or within the next few days, which has a few interface changes.

As part of this process, I'm looking at a number of packages that depend on generics-sop, and see how their code is impacted by the change.

In the case of `getopt-generics`, the changes are as follows:
- The definition of `Al`l has changed, and it is now a type class rather than a type family. Somewhat surprisingly, this implies that you need to enable `FlexibleContexts`now. Adding this extension is unproblematic for the old version, which means that with this modification, the library should actually work with both versions of `generics-sop`.
